### PR TITLE
fix merging of iCount summaries with premapped crosslinks

### DIFF
--- a/modules/local/merge_summary/main.nf
+++ b/modules/local/merge_summary/main.nf
@@ -8,10 +8,7 @@ process MERGE_SUMMARY {
         'biocontainers/pandas:1.4.3' }"
 
     input:
-    tuple val(meta), path(summary_type)
-    tuple val(meta), path(summary_subtype)
-    tuple val(meta), path(summary_gene)
-    tuple val(meta), path(smrna_premapped_k1_cDNA)
+    tuple val(meta), path(summaries)
 
     output:
     tuple val(meta), path("*summary_type_premapadjusted.tsv")   , emit: summary_type_adjusted

--- a/modules/local/merge_summary/templates/merge_summary.py
+++ b/modules/local/merge_summary/templates/merge_summary.py
@@ -44,7 +44,9 @@ def adjust_summary_file(file_path, number_cdnas_premapped):
     df.to_csv(output_file, sep="\t", index=False)
 
 
-def main(processname, subtype, type, gene, cdna):
+def main(processname, summaries):
+    type, subtype, gene, cdna = summaries.split(" ")
+    
     # Dump version file
     dump_versions(processname)
 
@@ -61,10 +63,10 @@ if __name__ == "__main__":
     # Allows switching between nextflow templating and standalone python running using arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("--processname", default="!{process_name}")
-    parser.add_argument("--subtype", default="!{summary_subtype}")
-    parser.add_argument("--type", default="!{summary_type}")
-    parser.add_argument("--gene", default="!{summary_gene}")
-    parser.add_argument("--cdna", default="!{smrna_premapped_k1_cDNA}")
+    parser.add_argument("--summaries", default="!{summaries}")
     args = parser.parse_args()
 
-    main(args.processname, args.subtype, args.type, args.gene, args.cdna)
+    print("Process name: " + args.processname)
+    print("Summaries: " + args.summaries)
+    main(args.processname, args.summaries)
+    

--- a/nextflow.config
+++ b/nextflow.config
@@ -180,7 +180,6 @@ profiles {
     docker {
         docker.enabled         = true
         docker.registry        = 'quay.io'
-        docker.userEmulation   = true
         docker.runOptions      = '-u $(id -u):$(id -g)'
         conda.enabled          = false
         singularity.enabled    = false

--- a/workflows/clipseq.nf
+++ b/workflows/clipseq.nf
@@ -427,11 +427,17 @@ workflow CLIPSEQ {
             ch_regions_used.map{ it[1] }
         )
 
+        ch_merged_summaries = ICOUNTMINI_SUMMARY.out.summary_type
+            .join( ICOUNTMINI_SUMMARY.out.summary_subtype, by: [0])
+            .join( ICOUNTMINI_SUMMARY.out.summary_gene, by: [0])
+            .join( ch_ncrna_k1_crosslink_group_resolved_bed, by: [0])
+            .map { meta, type, subtype, gene, bed -> 
+                [meta, [type, subtype, gene, bed]]
+            }
+
+
         MERGE_SUMMARY (
-            ICOUNTMINI_SUMMARY.out.summary_type,
-            ICOUNTMINI_SUMMARY.out.summary_subtype,
-            ICOUNTMINI_SUMMARY.out.summary_gene,
-            ch_ncrna_k1_crosslink_group_resolved_bed
+            ch_merged_summaries
         )
         ch_versions = ch_versions.mix(MERGE_SUMMARY.out.versions)
 


### PR DESCRIPTION
This fix was implemented in goodwrigth/clipseq 9dfeafe to tweak the channel creation for MERGE_SUMMARY process. In its previous iteration, the premmaped cDNA crosslink files could be randomly paired with other icount summary files to produce erroneous "premapadjusted" icount summary files.

The fix addressed this issue by Joining all summaries and premapped bed file into one stream, based on the corresponding metadata key (sample name).

<!--
# nf-core/clipseq pull request

Many thanks for contributing to nf-core/clipseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/clipseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/clipseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/clipseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
